### PR TITLE
Move all logic to the renderer class

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "react-cardiogram",
   "description": "Animated cardiogram component for React",
-  "version": "1.0.0-beta.5",
+  "version": "1.0.0-beta.6",
   "license": "MIT",
   "author": "Dmitriy Kudelko <dmitriy.kudelko@gmail.com>",
   "source": "src/index.tsx",

--- a/src/lib/IntervalManager.ts
+++ b/src/lib/IntervalManager.ts
@@ -1,0 +1,16 @@
+export default class IntervalManager {
+  private intervalIds: number[] = []
+
+  public setInterval(handler: TimerHandler, timeout?: number): number {
+    const intervalId = window.setInterval(handler, timeout)
+    this.intervalIds.push(intervalId)
+
+    return intervalId
+  }
+
+  public clearAll(): void {
+    this.intervalIds.forEach((intervalId) => {
+      window.clearInterval(intervalId)
+    })
+  }
+}

--- a/src/lib/defaults.ts
+++ b/src/lib/defaults.ts
@@ -1,7 +1,6 @@
 import { RenderOptions } from './CanvasRenderer'
-import { OtherOptions } from './types'
 
-const defaults: RenderOptions & OtherOptions = {
+const defaults: RenderOptions = {
   width: 500,
   height: 100,
   color: '#22ff22',

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -1,12 +1,6 @@
 import { RenderOptions } from './CanvasRenderer'
 
-export type CardiogramProps = Partial<RenderOptions> & Partial<OtherOptions>
-
-export interface OtherOptions {
-  paintInterval: number
-  density: number
-  beatFrequency?: number
-}
+export type CardiogramProps = Partial<RenderOptions>
 
 export interface ManualBangHandle {
   bang: () => void

--- a/src/lib/use-cardiogram.ts
+++ b/src/lib/use-cardiogram.ts
@@ -6,21 +6,14 @@ import {
   useRef,
   useState
 } from 'react'
-import useInterval from 'use-interval'
 
-import {
-  spikeValues,
-  createBeatRange,
-  getIdleBeatValue,
-  getNextBeatIndex,
-  getSpikeValue,
-  constraintWithinRange
-} from './util'
+import { constraintWithinRange } from './util'
 import useWindowResize from './use-window-resize'
 import CanvasRenderer, { RenderOptions } from './CanvasRenderer'
-import { ManualBangHandle, OtherOptions } from './types'
+import { ManualBangHandle } from './types'
+import IntervalManager from './IntervalManager'
 
-interface Props extends Omit<RenderOptions, 'width'>, OtherOptions {
+interface Props extends Omit<RenderOptions, 'width'> {
   defaultWidth: number
   ref: Ref<ManualBangHandle>
 }
@@ -48,21 +41,17 @@ const useCardiogram: UseCardiogram = ({
   ref
 }) => {
   const [width, setWidth] = useState<number>(defaultWidth)
-  const [isSpike, setIsSpike] = useState<boolean>(false)
 
-  const beatIndex = useRef<number>(0)
-  const spikeIndex = useRef<number>(-1)
+  const renderer = useRef<CanvasRenderer>()
   const canvas = useRef<HTMLCanvasElement>(null)
   const container = useRef<HTMLDivElement>(null)
-  const beats = useRef<number[]>([])
-  const [renderer, setRenderer] = useState<CanvasRenderer>()
 
   // draws a spike
   const bang = useCallback(() => {
-    setIsSpike(true)
+    renderer.current?.renderSpike()
   }, [])
 
-  // exposes bang method so that it could be invoked externally vie ref.bang()
+  // exposes bang method so that it could be invoked externally via ref.bang()
   useImperativeHandle(ref, () => ({
     bang
   }))
@@ -71,55 +60,10 @@ const useCardiogram: UseCardiogram = ({
     if (container.current) {
       const { width } = container.current.getBoundingClientRect()
       setWidth(width)
-
-      beats.current = createBeatRange(width, density)
     }
-  }, [density])
-
-  useWindowResize(onResize)
-
-  const setBeatValue = useCallback<(value: number) => void>((value) => {
-    beats.current[beatIndex.current] = value
   }, [])
 
-  const fillSpikeData = useCallback(() => {
-    setBeatValue(getSpikeValue(spikeIndex.current))
-
-    spikeIndex.current =
-      spikeIndex.current < spikeValues.length ? spikeIndex.current + 1 : -1
-  }, [setBeatValue])
-
-  const fillIdleData = useCallback(() => {
-    setBeatValue(getIdleBeatValue())
-  }, [setBeatValue])
-
-  const updateData = useCallback(() => {
-    beatIndex.current = getNextBeatIndex(
-      beatIndex.current,
-      beats.current.length
-    )
-
-    if (spikeIndex.current >= 0 || isSpike) {
-      fillSpikeData()
-      setIsSpike(false)
-    } else {
-      fillIdleData()
-    }
-  }, [isSpike, fillSpikeData, fillIdleData])
-
-  const paint = useCallback(() => {
-    renderer?.render(beats.current, beatIndex.current)
-  }, [renderer])
-
-  useInterval(
-    () => {
-      updateData()
-      paint()
-    },
-    renderer ? paintInterval : false
-  )
-
-  useInterval(bang, renderer && beatFrequency ? beatFrequency : false)
+  useWindowResize(onResize)
 
   useEffect(() => {
     const ctx = canvas.current?.getContext('2d')
@@ -128,17 +72,32 @@ const useCardiogram: UseCardiogram = ({
       return
     }
 
-    const renderer = new CanvasRenderer(ctx, {
+    renderer.current = new CanvasRenderer(ctx, new IntervalManager(), {
       width,
       height,
       color,
       thickness,
       scale: constraintWithinRange(scale, 5, 100),
-      cursorSize
+      cursorSize,
+      density,
+      paintInterval,
+      beatFrequency
     })
 
-    setRenderer(renderer)
-  }, [width, height, color, thickness, scale, cursorSize])
+    return () => {
+      renderer.current?.destroy()
+    }
+  }, [
+    width,
+    height,
+    color,
+    thickness,
+    scale,
+    cursorSize,
+    density,
+    paintInterval,
+    beatFrequency
+  ])
 
   return {
     width,


### PR DESCRIPTION
The aim of this PR is to eliminate the initial complexity of `useCardiogram` hook by moving all what can be moved to the renderer class.